### PR TITLE
Replace deprecated enterprise keyword

### DIFF
--- a/workspace.dsl
+++ b/workspace.dsl
@@ -8,7 +8,7 @@ workspace "Government Body" "This is an example workspace to illustrate the key 
 
         email = softwaresystem "GovNotify" "The Government Service for sending e-maills." "Existing System"
 
-        enterprise "Government Body" {
+        group "Government Body" {
             supportStaff = person "Citizen Service Staff" "Citizen service staff within the Government." "Civil Servant Staff" {
                 properties {
                     "Location" "Customer Services"


### PR DESCRIPTION
As it stands right now, you get the following error when you follow the **Local Interactive Server** instructions
```
 ERROR 1 --- [nio-8080-exec-1] s.l.c.w.FileSystemWorkspaceComponentImpl : com.structurizr.dsl.StructurizrDslParserException: The enterprise keyword was previously deprecated, and has now been removed - please use group instead (https://docs.structurizr.com/dsl/language#group) at line 11 of /usr/local/structurizr/workspace.dsl: enterprise "Government Body" {
```